### PR TITLE
Rename Number to DecimalNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ You can find out more about floating point precision [here](http://php.net/float
 
 Example:
 ```php
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Rounding;
 
-echo (new Number('0.1'))
-    ->plus(new Number('0.7'))
-    ->times(new Number('10'))
+echo (new DecimalNumber('0.1'))
+    ->plus(new DecimalNumber('0.7'))
+    ->times(new DecimalNumber('10'))
     ->round(0, Rounding::ROUND_FLOOR)
   
 // echoes '8'
@@ -49,29 +49,29 @@ Quick links:
 ### Instantiation
 Creates a new Decimal number.
 ```php
-public Number Number::__construct ( string $number [, int $exponent = null ] )
+public __construct ( string $number [, int $exponent = null ] ): DecimalNumber
 ```
-There are two ways to instantiate a Decimal\Number:
+There are two ways to instantiate a Decimal\DecimalNumber:
 ``` php
 // create a number from string
-$number = new PrestaShop\Decimal\Number('123.456');
+$number = new PrestaShop\Decimal\DecimalNumber('123.456');
 echo $number; // echoes '123.456'
 ```
 ``` php
 // exponent notation
-$number = new PrestaShop\Decimal\Number('123456', -3);
+$number = new PrestaShop\Decimal\DecimalNumber('123456', -3);
 echo $number; // echoes '123.456'
 ```
 
 ### Addition
 Returns the computed result of adding another number to the current one.
 ```php
-public Number Number::plus ( Number $addend )
+public DecimalNumber::plus ( DecimalNumber $addend ): DecimalNumber
 ```
 Examples:
 ```php
-$a = new PrestaShop\Decimal\Number('123.456');
-$b = new PrestaShop\Decimal\Number('654.321');
+$a = new PrestaShop\Decimal\DecimalNumber('123.456');
+$b = new PrestaShop\Decimal\DecimalNumber('654.321');
 
 echo $a->plus($b); // echoes '777.777'
 ```
@@ -79,12 +79,12 @@ echo $a->plus($b); // echoes '777.777'
 ### Subtraction
 Returns the computed result of subtracting another number to the current one.
 ```php
-public Number Number::minus ( Number $subtrahend )
+public DecimalNumber::minus ( DecimalNumber $subtrahend ): DecimalNumber
 ```
 Examples:
 ```php
-$a = new PrestaShop\Decimal\Number('777.777');
-$b = new PrestaShop\Decimal\Number('654.321');
+$a = new PrestaShop\Decimal\DecimalNumber('777.777');
+$b = new PrestaShop\Decimal\DecimalNumber('654.321');
 
 echo $a->minus($b); // echoes '123.456'
 ```
@@ -92,12 +92,12 @@ echo $a->minus($b); // echoes '123.456'
 ### Multiplication
 Returns the computed result of multiplying the current number with another one.
 ```php
-public Number Number::times ( Number $factor )
+public DecimalNumber::times ( DecimalNumber $factor ): DecimalNumber
 ```
 Examples:
 ```php
-$a = new PrestaShop\Decimal\Number('777.777');
-$b = new PrestaShop\Decimal\Number('654.321');
+$a = new PrestaShop\Decimal\DecimalNumber('777.777');
+$b = new PrestaShop\Decimal\DecimalNumber('654.321');
 
 echo $a->times($b); // echoes '508915.824417'
 ```
@@ -105,12 +105,12 @@ echo $a->times($b); // echoes '508915.824417'
 ### Division
 Returns the computed result of dividing  the current number by another one, with up to a certain number of decimal positions (6 by default).
 ```php
-public Number Number::dividedBy ( Number $divisor [, int $precision = Operation\Division::DEFAULT_PRECISION ] )
+public DecimalNumber::dividedBy ( DecimalNumber $divisor [, int $precision = Operation\Division::DEFAULT_PRECISION ] )
 ```
 Examples:
 ```php
-$a = new PrestaShop\Decimal\Number('777.777');
-$b = new PrestaShop\Decimal\Number('654.321');
+$a = new PrestaShop\Decimal\DecimalNumber('777.777');
+$b = new PrestaShop\Decimal\DecimalNumber('654.321');
 
 echo $a->dividedBy($b, 0);  // echoes '1'
 echo $a->dividedBy($b, 5);  // echoes '1.18867'
@@ -121,8 +121,8 @@ echo $a->dividedBy($b, 15); // echoes '1.188678034175886'
 ### Comparison
 Returns the result of the comparison assertion.
 ```php
-$a = new PrestaShop\Decimal\Number('777.777');
-$b = new PrestaShop\Decimal\Number('654.321');
+$a = new PrestaShop\Decimal\DecimalNumber('777.777');
+$b = new PrestaShop\Decimal\DecimalNumber('654.321');
 
 $a->equals($b);                // returns false
 $a->isLowerThan($b);           // returns false
@@ -141,12 +141,12 @@ $a->isGreaterOrEqualThanZero(); // returns true
 ### Fixed precision
 Returns the number as a string, optionally rounded, with an exact number of decimal positions.
 ```php
-public string Number::toPrecision ( int $precision [, string $roundingMode = Rounding::ROUND_TRUNCATE ] )
+public DecimalNumber::toPrecision ( int $precision [, string $roundingMode = Rounding::ROUND_TRUNCATE ] ): string
 ```
 Examples:
 ```php
-$a = new PrestaShop\Decimal\Number('123.456');
-$a = new PrestaShop\Decimal\Number('-123.456');
+$a = new PrestaShop\Decimal\DecimalNumber('123.456');
+$a = new PrestaShop\Decimal\DecimalNumber('-123.456');
 
 // truncate / pad
 $a->toPrecision(0); // '123'
@@ -200,7 +200,7 @@ $a->toPrecision(0, PrestaShop\Decimal\Operation\Rounding::ROUND_HALF_EVEN); // '
 $a->toPrecision(1, PrestaShop\Decimal\Operation\Rounding::ROUND_HALF_EVEN); // '-123.4'
 $a->toPrecision(2, PrestaShop\Decimal\Operation\Rounding::ROUND_HALF_EVEN); // '-123.46'
 
-$a = new Decimal\Number('1.1525354556575859505');
+$a = new PrestaShop\Decimal\DecimalNumber('1.1525354556575859505');
 $a->toPrecision(0, PrestaShop\Decimal\Operation\Rounding::ROUND_HALF_EVEN);  // '1'
 $a->toPrecision(1, PrestaShop\Decimal\Operation\Rounding::ROUND_HALF_EVEN);  // '1.2'
 $a->toPrecision(2, PrestaShop\Decimal\Operation\Rounding::ROUND_HALF_EVEN);  // '1.15'
@@ -218,12 +218,12 @@ $a->toPrecision(10, PrestaShop\Decimal\Operation\Rounding::ROUND_HALF_EVEN); // 
 Rounding behaves like `toPrecision`, but provides "up to" a certain number of decimal positions
 (it does not add trailing zeroes).
 ```php
-public string Number::round ( int $maxDecimals [, string $roundingMode = Rounding::ROUND_TRUNCATE ] )
+public DecimalNumber::round ( int $maxDecimals [, string $roundingMode = Rounding::ROUND_TRUNCATE ] ): string
 ```
 Examples:
 ```php
-$a = new PrestaShop\Decimal\Number('123.456');
-$a = new PrestaShop\Decimal\Number('-123.456');
+$a = new PrestaShop\Decimal\DecimalNumber('123.456');
+$a = new PrestaShop\Decimal\DecimalNumber('-123.456');
 
 // truncate / pad
 $a->round(0); // '123'
@@ -241,11 +241,11 @@ $b->round(4); // '-123.456'
 ### Dot shifting
 Creates a new copy of this number multiplied by 10^exponent
 ```php
-public Number Number::toMagnitude ( int $exponent )
+public DecimalNumber::toMagnitude ( int $exponent ): DecimalNumber
 ```
 Examples:
 ```php
-$a = new Decimal\Number('123.456789');
+$a = new PrestaShop\Decimal\DecimalNumber('123.456789');
 
 // shift 3 digits to the left
 $a->toMagnitude(-3); // 0.123456789
@@ -256,7 +256,7 @@ $a->toMagnitude(3); // 123456.789
 
 ### Useful methods
 ```php
-$number = new PrestaShop\Decimal\Number('123.45');
+$number = new PrestaShop\Decimal\DecimalNumber('123.45');
 $number->getIntegerPart();    // '123'
 $number->getFractionalPart(); // '45'
 $number->getPrecision();      // '2' (number of decimals)
@@ -265,7 +265,7 @@ $number->getExponent();       // '2' (always positive)
 $number->getCoefficient();    // '123456'
 $number->isPositive();        // true
 $number->isNegative();        // false
-$number->invert();            // new Decimal\Number('-123.45')
+$number->invert();            // new Decimal\DecimalNumber('-123.45')
 ```
 
 ## Testing

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal;
 
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 
 
 /**
@@ -32,7 +32,7 @@ class Builder
      *
      * @param string $number
      *
-     * @return Number
+     * @return DecimalNumber
      */
     public static function parseNumber($number)
     {
@@ -78,7 +78,7 @@ class Builder
             }
         }
 
-        return new Number($numberParts['sign'] . $coefficient, $fractionalDigits);
+        return new DecimalNumber($numberParts['sign'] . $coefficient, $fractionalDigits);
     }
 
     /**

--- a/src/DecimalNumber.php
+++ b/src/DecimalNumber.php
@@ -16,7 +16,7 @@ use PrestaShop\Decimal\Operation\Rounding;
  *
  * Allows for arbitrary precision math operations.
  */
-class Number
+class DecimalNumber
 {
 
     /**
@@ -58,7 +58,7 @@ class Number
      * Note: decimal positions must always be a positive number.
      *
      * @param string $number Number or coefficient
-     * @param int $exponent [default=null] If provided, the number can be considered as the negative
+     * @param int|null $exponent [default=null] If provided, the number can be considered as the negative
      * exponent of the scientific notation, or the number of fractional digits.
      */
     public function __construct($number, $exponent = null)

--- a/src/Number.php
+++ b/src/Number.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the PrestaShop\Decimal package
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PrestaShop\Decimal;
+
+/**
+ * Retrocompatible name for DecimalNumber
+ *
+ * @deprecated use DecimalNumber instead
+ */
+class Number extends DecimalNumber
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($number, $exponent = null)
+    {
+        @trigger_error(__FUNCTION__ . 'is deprecated since version 1.4. Use DecimalNumber instead.', E_USER_DEPRECATED);
+
+        parent::__construct($number, $exponent);
+    }
+}

--- a/src/Operation/Addition.php
+++ b/src/Operation/Addition.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Operation;
 
-use PrestaShop\Decimal\Number as DecimalNumber;
+use PrestaShop\Decimal\DecimalNumber;
 
 /**
  * Computes the addition of two decimal numbers

--- a/src/Operation/Comparison.php
+++ b/src/Operation/Comparison.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Operation;
 
-use PrestaShop\Decimal\Number as DecimalNumber;
+use PrestaShop\Decimal\DecimalNumber;
 
 /**
  * Compares two decimal numbers

--- a/src/Operation/Division.php
+++ b/src/Operation/Division.php
@@ -9,7 +9,7 @@
 namespace PrestaShop\Decimal\Operation;
 
 use PrestaShop\Decimal\Exception\DivisionByZeroException;
-use PrestaShop\Decimal\Number as DecimalNumber;
+use PrestaShop\Decimal\DecimalNumber;
 
 /**
  * Computes the division between two decimal numbers.

--- a/src/Operation/MagnitudeChange.php
+++ b/src/Operation/MagnitudeChange.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Operation;
 
-use PrestaShop\Decimal\Number as DecimalNumber;
+use PrestaShop\Decimal\DecimalNumber;
 
 /**
  * Computes relative magnitude changes on a decimal number

--- a/src/Operation/Multiplication.php
+++ b/src/Operation/Multiplication.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Operation;
 
-use PrestaShop\Decimal\Number as DecimalNumber;
+use PrestaShop\Decimal\DecimalNumber;
 
 /**
  * Computes the multiplication between two decimal numbers

--- a/src/Operation/Rounding.php
+++ b/src/Operation/Rounding.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Operation;
 
-use PrestaShop\Decimal\Number as DecimalNumber;
+use PrestaShop\Decimal\DecimalNumber;
 
 /**
  * Allows transforming a decimal number's precision

--- a/src/Operation/Subtraction.php
+++ b/src/Operation/Subtraction.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Operation;
 
-use PrestaShop\Decimal\Number as DecimalNumber;
+use PrestaShop\Decimal\DecimalNumber;
 
 /**
  * Computes the subtraction of two decimal numbers

--- a/tests/DecimalNumberTest.php
+++ b/tests/DecimalNumberTest.php
@@ -6,12 +6,12 @@
  * @license   https://opensource.org/licenses/MIT MIT License
  */
 
-namespace PrestaShop\Decimal\tests\Unit\Core\Decimal;
+namespace PrestaShop\Decimal\Test;
 
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Rounding;
 
-class NumberTest extends \PHPUnit_Framework_TestCase
+class DecimalNumberTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -29,7 +29,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItInterpretsNumbers($number, $expectedSign, $expectedInteger, $expectedFraction, $expectedStr)
     {
-        $decimalNumber = new Number($number);
+        $decimalNumber = new DecimalNumber($number);
         $this->assertSame($expectedSign, $decimalNumber->getSign(), 'The sign is not as expected');
         $this->assertSame($expectedInteger, $decimalNumber->getIntegerPart(), 'The integer part is not as expected');
         $this->assertSame(
@@ -53,7 +53,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItInterpretsExponents($coefficient, $exponent, $expectedStr)
     {
-        $decimalNumber = new Number($coefficient, $exponent);
+        $decimalNumber = new DecimalNumber($coefficient, $exponent);
         $this->assertSame($expectedStr, (string) $decimalNumber);
     }
 
@@ -69,7 +69,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItThrowsExceptionWhenGivenInvalidNumber($number)
     {
-        new Number($number);
+        new DecimalNumber($number);
     }
 
     /**
@@ -85,7 +85,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItThrowsExceptionWhenGivenInvalidCoefficientOrExponent($coefficient, $exponent)
     {
-        new Number($coefficient, $exponent);
+        new DecimalNumber($coefficient, $exponent);
     }
 
     /**
@@ -100,7 +100,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItDropsNonSignificantDigits($number, $expected)
     {
-        $decimalNumber = new Number($number);
+        $decimalNumber = new DecimalNumber($number);
         $this->assertSame($expected, (string) $decimalNumber);
     }
 
@@ -118,7 +118,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testPrecision($number, $precision, $mode, $expected)
     {
-        $decimalNumber = new Number($number);
+        $decimalNumber = new DecimalNumber($number);
         $this->assertSame($expected, (string) $decimalNumber->toPrecision($precision, $mode));
     }
 
@@ -136,7 +136,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testRounding($number, $precision, $mode, $expected)
     {
-        $decimalNumber = new Number($number);
+        $decimalNumber = new DecimalNumber($number);
         $this->assertSame(
             $expected,
             (string) $decimalNumber->round($precision, $mode),
@@ -157,7 +157,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItExtendsPrecisionAsNeeded($number, $precision, $expected)
     {
-        $decimalNumber = new Number($number);
+        $decimalNumber = new DecimalNumber($number);
         $this->assertSame(
             $expected,
             (string) $decimalNumber->toPrecision($precision),
@@ -170,8 +170,8 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      * When comparing the first one with the second one
      * Then the result should be true if the instances are equal, and false otherwise
      *
-     * @param Number $number1
-     * @param Number $number2
+     * @param DecimalNumber $number1
+     * @param DecimalNumber $number2
      * @param string $expected
      *
      * @dataProvider provideEqualityTestCases
@@ -199,8 +199,8 @@ class NumberTest extends \PHPUnit_Framework_TestCase
     public function testIsAbleToTellIfGreaterThan($number1, $number2, $expected)
     {
         $shouldBeGreater = (1 === $expected);
-        $number1 = new Number($number1);
-        $number2 = new Number($number2);
+        $number1 = new DecimalNumber($number1);
+        $number2 = new DecimalNumber($number2);
 
         $this->assertSame($number1->isGreaterThan($number2), $shouldBeGreater);
     }
@@ -219,8 +219,8 @@ class NumberTest extends \PHPUnit_Framework_TestCase
     public function testIsAbleToTellIfLowerThan($number1, $number2, $expected)
     {
         $shouldBeLower = (-1 === $expected);
-        $number1 = new Number($number1);
-        $number2 = new Number($number2);
+        $number1 = new DecimalNumber($number1);
+        $number2 = new DecimalNumber($number2);
 
         $this->assertSame($number1->isLowerThan($number2), $shouldBeLower);
     }
@@ -237,7 +237,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItTransformsPositiveToNegative($number, $expected)
     {
-        $number = (new Number($number))
+        $number = (new DecimalNumber($number))
             ->toNegative();
 
         $this->assertSame((string) $number, $expected);
@@ -255,7 +255,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testItTransformsNegativeToPositive($number, $expected)
     {
-        $number = (new Number($number))
+        $number = (new DecimalNumber($number))
             ->toPositive();
 
         $this->assertSame((string) $number, $expected);
@@ -510,43 +510,43 @@ class NumberTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new Number('0'),
-                new Number('0', 5),
+                new DecimalNumber('0'),
+                new DecimalNumber('0', 5),
                 true
             ],
             [
-                new Number('0.1234'),
-                new Number('1234', 4),
+                new DecimalNumber('0.1234'),
+                new DecimalNumber('1234', 4),
                 true
             ],
             [
-                new Number('1234.01'),
-                new Number('123401', 2),
+                new DecimalNumber('1234.01'),
+                new DecimalNumber('123401', 2),
                 true
             ],
             [
-                new Number('-0'),
-                new Number('0'),
+                new DecimalNumber('-0'),
+                new DecimalNumber('0'),
                 true
             ],
             [
-                new Number('-1234.01'),
-                new Number('-123401', 2),
+                new DecimalNumber('-1234.01'),
+                new DecimalNumber('-123401', 2),
                 true
             ],
             [
-                new Number('-1234.01'),
-                new Number('123401', 2),
+                new DecimalNumber('-1234.01'),
+                new DecimalNumber('123401', 2),
                 false
             ],
             [
-                new Number('1234.01'),
-                new Number('-123401', 2),
+                new DecimalNumber('1234.01'),
+                new DecimalNumber('-123401', 2),
                 false
             ],
             [
-                new Number('1234.01'),
-                new Number('-1234.01'),
+                new DecimalNumber('1234.01'),
+                new DecimalNumber('-1234.01'),
                 false
             ],
         ];

--- a/tests/Operation/AdditionTest.php
+++ b/tests/Operation/AdditionTest.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Test\Operation;
 
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Addition;
 
 class AdditionTest extends \PHPUnit_Framework_TestCase
@@ -27,8 +27,8 @@ class AdditionTest extends \PHPUnit_Framework_TestCase
      */
     public function testItAddsNumbers($number1, $number2, $expectedResult)
     {
-        $n1 = new Number($number1);
-        $n2 = new Number($number2);
+        $n1 = new DecimalNumber($number1);
+        $n2 = new DecimalNumber($number2);
 
         $operation = new Addition();
         $result1 = $operation->computeUsingBcMath($n1, $n2);

--- a/tests/Operation/ComparisonTest.php
+++ b/tests/Operation/ComparisonTest.php
@@ -9,20 +9,20 @@
 namespace PrestaShop\Decimal\Test\Operation;
 
 use PHPUnit_Framework_TestCase;
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Comparison;
 
 class ComparisonTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * @var Number
+     * @var DecimalNumber
      */
     private static $zero;
 
     public static function setUpBeforeClass()
     {
-        static::$zero = new Number('0');
+        static::$zero = new DecimalNumber('0');
     }
 
     /**
@@ -43,8 +43,8 @@ class ComparisonTest extends PHPUnit_Framework_TestCase
     {
         $comparison = new Comparison();
 
-        $result1 = $comparison->compareUsingBcMath(new Number($a), new Number($b));
-        $result2 = $comparison->compareWithoutBcMath(new Number($a), new Number($b));
+        $result1 = $comparison->compareUsingBcMath(new DecimalNumber($a), new DecimalNumber($b));
+        $result2 = $comparison->compareWithoutBcMath(new DecimalNumber($a), new DecimalNumber($b));
 
         $this->assertSame($expected, $result1, "Failed assertion (BC Math)");
         $this->assertSame($expected, $result2, "Failed assertion");
@@ -92,7 +92,7 @@ class ComparisonTest extends PHPUnit_Framework_TestCase
      */
     public function testItDetectsEqualsZero($number, $expected)
     {
-        $n = new Number($number);
+        $n = new DecimalNumber($number);
 
         $this->assertSame(
             $expected,
@@ -139,7 +139,7 @@ class ComparisonTest extends PHPUnit_Framework_TestCase
      */
     public function testItDetectsGreaterThanZero($number, $expected)
     {
-        $n = new Number($number);
+        $n = new DecimalNumber($number);
 
         $this->assertSame(
             $expected,
@@ -186,7 +186,7 @@ class ComparisonTest extends PHPUnit_Framework_TestCase
      */
     public function testItDetectsGreaterOrEqualThanZero($number, $expected)
     {
-        $n = new Number($number);
+        $n = new DecimalNumber($number);
 
         $this->assertSame(
             $expected,
@@ -233,7 +233,7 @@ class ComparisonTest extends PHPUnit_Framework_TestCase
      */
     public function testItDetectsLowerThanZero($number, $expected)
     {
-        $n = new Number($number);
+        $n = new DecimalNumber($number);
 
         $this->assertSame(
             $expected,
@@ -280,7 +280,7 @@ class ComparisonTest extends PHPUnit_Framework_TestCase
      */
     public function testItDetectsLowerOrEqualThanZero($number, $expected)
     {
-        $n = new Number($number);
+        $n = new DecimalNumber($number);
 
         $this->assertSame(
             $expected,
@@ -325,5 +325,4 @@ class ComparisonTest extends PHPUnit_Framework_TestCase
     {
         return ($assertion) ? 'is' : 'is NOT';
     }
-
 }

--- a/tests/Operation/DivisionTest.php
+++ b/tests/Operation/DivisionTest.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Test\Operation;
 
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Division;
 
 class DivisionTest extends \PHPUnit_Framework_TestCase
@@ -27,8 +27,8 @@ class DivisionTest extends \PHPUnit_Framework_TestCase
      */
     public function testItDividesNumbers($number1, $number2, $expectedResult)
     {
-        $n1 = new Number($number1);
-        $n2 = new Number($number2);
+        $n1 = new DecimalNumber($number1);
+        $n2 = new DecimalNumber($number2);
 
         $operation = new Division();
         $result1 = $operation->computeUsingBcMath($n1, $n2, 20);
@@ -48,8 +48,8 @@ class DivisionTest extends \PHPUnit_Framework_TestCase
     public function testDivisionByZeroUsingBcMathThrowsException()
     {
         (new Division())->computeUsingBcMath(
-            new Number('1'),
-            new Number('0')
+            new DecimalNumber('1'),
+            new DecimalNumber('0')
         );
     }
 
@@ -63,8 +63,8 @@ class DivisionTest extends \PHPUnit_Framework_TestCase
     public function testDivisionByZeroWithoutBcMathThrowsException()
     {
         (new Division())->computeWithoutBcMath(
-            new Number('1'),
-            new Number('0')
+            new DecimalNumber('1'),
+            new DecimalNumber('0')
         );
     }
 

--- a/tests/Operation/MagnitudeChangeTest.php
+++ b/tests/Operation/MagnitudeChangeTest.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Test\Operation;
 
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\MagnitudeChange;
 
 class MagnitudeChangeTest extends \PHPUnit_Framework_TestCase
@@ -28,7 +28,7 @@ class MagnitudeChangeTest extends \PHPUnit_Framework_TestCase
      */
     public function testItChangesMagnitude($number, $exponent, $expected)
     {
-        $n = new Number($number);
+        $n = new DecimalNumber($number);
 
         $result = (new MagnitudeChange())->compute($n, $exponent);
 

--- a/tests/Operation/MultiplicationTest.php
+++ b/tests/Operation/MultiplicationTest.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Test\Operation;
 
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Multiplication;
 
 class MultiplicationTest extends \PHPUnit_Framework_TestCase
@@ -27,8 +27,8 @@ class MultiplicationTest extends \PHPUnit_Framework_TestCase
      */
     public function testItMultipliesNumbers($number1, $number2, $expectedResult)
     {
-        $n1 = new Number($number1);
-        $n2 = new Number($number2);
+        $n1 = new DecimalNumber($number1);
+        $n2 = new DecimalNumber($number2);
 
         $operation = new Multiplication();
         $result1 = $operation->computeUsingBcMath($n1, $n2);

--- a/tests/Operation/RoundingTest.php
+++ b/tests/Operation/RoundingTest.php
@@ -9,7 +9,7 @@
 namespace PrestaShop\Decimal\Test\Operation;
 
 use PrestaShop\Decimal\Operation\Rounding;
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 
 class RoundingTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,7 +23,7 @@ class RoundingTest extends \PHPUnit_Framework_TestCase
      */
     public function testItThrowsExceptionIfRoundingModeIsInvalid()
     {
-        $decimalNumber = new Number('1.2345');
+        $decimalNumber = new DecimalNumber('1.2345');
         $rounding = new Rounding();
 
         $rounding->compute(
@@ -46,7 +46,7 @@ class RoundingTest extends \PHPUnit_Framework_TestCase
      */
     public function testItThrowsExceptionIfPrecisionIsInvalid($precision)
     {
-        $decimalNumber = new Number('1.2345');
+        $decimalNumber = new DecimalNumber('1.2345');
         $rounding = new Rounding();
 
         $rounding->compute(
@@ -189,7 +189,7 @@ class RoundingTest extends \PHPUnit_Framework_TestCase
      */
     public function roundNumber($number, $precision, $mode, $expected)
     {
-        $decimalNumber = new Number($number);
+        $decimalNumber = new DecimalNumber($number);
         $rounding = new Rounding();
 
         $result = $rounding->compute(

--- a/tests/Operation/SubtractionTest.php
+++ b/tests/Operation/SubtractionTest.php
@@ -8,7 +8,7 @@
 
 namespace PrestaShop\Decimal\Test\Operation;
 
-use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Subtraction;
 
 class SubtractionTest extends \PHPUnit_Framework_TestCase
@@ -27,8 +27,8 @@ class SubtractionTest extends \PHPUnit_Framework_TestCase
      */
     public function testItSubtractsNumbers($number1, $number2, $expectedResult)
     {
-        $n1 = new Number($number1);
-        $n2 = new Number($number2);
+        $n1 = new DecimalNumber($number1);
+        $n2 = new DecimalNumber($number2);
 
         $operation = new Subtraction();
         $result1 = $operation->computeUsingBcMath($n1, $n2);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Rename Number to DecimalNumber to avoid collision with internal PHP type called "Number". Existing code will continue to work.
| Type?         | improvement
| BC breaks?    | no - `Number` extends `DecimalNumber` so everything should continue to work as expected.
| Deprecations? | yes - `Number` is now deprecated in favor of `DecimalNumber`
| Fixed ticket? | N/A
| How to test?  | Validated by automatic tests

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
