### PR TITLE
Update Builder.php

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -20,7 +20,7 @@ class Builder
     /**
      * Pattern for most numbers
      */
-    const NUMBER_PATTERN = "/^(?<sign>[-+])?(?<integerPart>\d+)?(?:\.(?<fractionalPart>\d+)(?<exponentPart>[eE](?<exponentSign>[-+])(?<exponent>\d+))?)?$/";
+    const NUMBER_PATTERN = "/^(?<sign>[-+])?(?<integerPart>\d+)?(?:[\.,](?<fractionalPart>\d+)(?<exponentPart>[eE](?<exponentSign>[-+])(?<exponent>\d+))?)?$/";
 
     /**
      * Pattern for integer numbers in scientific notation (rare but supported by spec)


### PR DESCRIPTION
Prevent InvalidArgumentException "cannot be interpreted as a number" when local set float number separator as a comma not a dot.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Prevent InvalidArgumentException "cannot be interpreted as a number" when local set decimal separator as a comma not a dot.
| Type?             | bug fix
| BC breaks?        | no
| Category?        | LO
| Deprecations?     | no
| Fixed ticket?     | Fixes #11.
| How to test?      | Local set to fr and cart filled with shipping cost with digits after the decimal point.
| Possible impacts? | Front home page only...

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
